### PR TITLE
Add FBOpen custom description appending script

### DIFF
--- a/config/scripts/fbopen/append_desc.mvel
+++ b/config/scripts/fbopen/append_desc.mvel
@@ -1,0 +1,1 @@
+if (ctx._source.containsKey("description")) {ctx._source.description += "\nModified " + posted_dt + ":\n" + description}


### PR DESCRIPTION
In theory, this script should be accessible to Elasticsearch at `fbopen_append_desc`.
